### PR TITLE
Use items table

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GIT
 PATH
   remote: .
   specs:
-    lims-warehousebuilder (0.5.1)
+    lims-warehousebuilder (0.5.2)
       aequitas
       amqp
       facets

--- a/db/migrations/001_create_tables.rb
+++ b/db/migrations/001_create_tables.rb
@@ -119,10 +119,11 @@ Sequel.migration do
     # items
     create_table :current_items do
       primary_key :internal_id
+      Integer :order_id
+      String :role
       String :uuid, :fixed => true, :size => 64
       String :batch_uuid, :fixed => true, :size => 64
       String :status
-      String :role
       DateTime :created_at
       DateTime :updated_at
       String :created_by
@@ -132,10 +133,11 @@ Sequel.migration do
 
     create_table :historic_items do
       primary_key :internal_id
+      Integer :order_id
+      String :role
       String :uuid, :fixed => true, :size => 64
       String :batch_uuid, :fixed => true, :size => 64
       String :status
-      String :role
       DateTime :created_at
       DateTime :updated_at
       String :created_by

--- a/lib/lims-warehousebuilder/decoders/order_decoder.rb
+++ b/lib/lims-warehousebuilder/decoders/order_decoder.rb
@@ -11,8 +11,38 @@ module Lims::WarehouseBuilder
       # to be saved first to get its internal_id.
       def _call(options)
         order = super
-        [order, sample_management_activity]
+        [order, items, sample_management_activity]
       end
+
+      
+      def items
+        klass = Model.model_for("item")
+        order_uuid = @payload["uuid"]
+        date = @payload["date"]
+        user = @payload["user"]
+
+        [].tap do |items|
+          @payload["items"].each do |role, items_array|
+            items_array.each do |item|
+              item_uuid = item["uuid"]
+              status = item["status"]
+              batch_uuid = item["batch"]["uuid"] if item["batch"]
+
+              item = prepared_model(item_uuid, "item").tap do |i|
+                i.uuid = item_uuid
+                i.role = role
+                i.batch_uuid = batch_uuid
+                i.status = status
+                i.created_at = date
+                i.created_by = user
+              end
+              item.set_order_uuid(order_uuid)
+              items << item
+            end
+          end
+        end
+      end
+
 
       # @return [Array<Model::SampleManagementActivity>]
       def sample_management_activity
@@ -30,21 +60,23 @@ module Lims::WarehouseBuilder
 
               begin
                 samples_info = SampleContainerHelper.samples_info_by_item_uuid(item_uuid)
-                samples_info.each do |sample_info|
-                  activity = klass.new({
-                    :uuid => sample_info[:sample_uuid],
-                    :process => process,
-                    :step => role,
-                    :user => user,
-                    :date => date,
-                    :status => status
-                  })
-                  activity.set_sample_id!(sample_info[:sample_uuid])
-                  activity.set_sample_container_id!(sample_info[:container_uuid], sample_info[:container_model])
-                  activity.set_order_uuid(order_uuid)
-                  activities << activity 
+                unless samples_info.empty?
+                  samples_info.each do |sample_info|
+                    activity = klass.new({
+                      :uuid => sample_info[:sample_uuid],
+                      :process => process,
+                      :step => role,
+                      :user => user,
+                      :date => date,
+                      :status => status
+                    })
+                    activity.set_sample_id!(sample_info[:sample_uuid])
+                    activity.set_sample_container_id!(sample_info[:container_uuid], sample_info[:container_model])
+                    activity.set_order_uuid(order_uuid)
+                    activities << activity 
+                  end
                 end
-              rescue Model::NotFound, Model::DBSchemaError => e
+              rescue Model::DBSchemaError => e
                 raise MessageToBeRequeued.new(e.message)
               end
             end

--- a/lib/lims-warehousebuilder/decoders/sample_decoder.rb
+++ b/lib/lims-warehousebuilder/decoders/sample_decoder.rb
@@ -13,6 +13,7 @@ module Lims::WarehouseBuilder
           if @payload["ancestor_uuid"]
             # Sample which are part from other laboratory asset like tubes...
             objects << sample_container_association
+            objects << sample_management_activity
           else
             # Sample object from lims-management-app. Are not part
             # of other s2 resource so they don't have an ancestor_uuid.
@@ -25,6 +26,38 @@ module Lims::WarehouseBuilder
               objects << super unless @payload["ancestor_uuid"]
             end
           end
+        end
+      end
+
+      def sample_management_activity
+        sample_uuid = @payload["uuid"]
+        container_uuid = @payload["ancestor_uuid"]
+        container_type = @payload["ancestor_type"]
+        user = @payload["user"]
+        date = @payload["date"]
+
+        begin
+          item = Model::Item.item_by_uuid(container_uuid) 
+          sample = Model::Sample.sample_by_uuid(sample_uuid)
+          order = Model::Order.order_by_id(item.order_id)
+
+          activity = Model::SampleManagementActivity.new({
+            :sample_id => sample.internal_id,
+            :order_id => item.order_id,
+            :uuid => sample_uuid,
+            :process => order.pipeline,
+            :step => item.role,
+            :user => user,
+            :date => date,
+            :status => item.status
+          })
+          activity.set_sample_container_id!(container_uuid, container_type)
+          activity
+          # We do not requeue the message if a notfound exception is raised.
+          # The sample activity could be managed by the order_decoder in that case.
+        rescue Model::NotFound => e
+        rescue Model::DBSchemaError => e
+          raise MessageToBeRequeued.new(e.message)
         end
       end
 

--- a/lib/lims-warehousebuilder/decoders/sample_decoder.rb
+++ b/lib/lims-warehousebuilder/decoders/sample_decoder.rb
@@ -29,6 +29,13 @@ module Lims::WarehouseBuilder
         end
       end
 
+      # This method saves the sample activity for each sample
+      # found in a s2_resource. It succeeds if for the sample,
+      # we can find an item associated to its container uuid,
+      # a sample row and an order associated with its container.
+      # If not, we just skip, and the sample activity could be
+      # handled in the order_decoder.
+      # @return [Sequel::SampleManagementActivity,Nil]
       def sample_management_activity
         sample_uuid = @payload["uuid"]
         container_uuid = @payload["ancestor_uuid"]

--- a/lib/lims-warehousebuilder/models/common.rb
+++ b/lib/lims-warehousebuilder/models/common.rb
@@ -10,6 +10,7 @@ module Lims::WarehouseBuilder
       include TableMigration
 
       def before_save
+        super
         maintain_warehouse_for(self.class)
       end
 

--- a/lib/lims-warehousebuilder/models/helper_sample_container.rb
+++ b/lib/lims-warehousebuilder/models/helper_sample_container.rb
@@ -17,31 +17,14 @@ module Lims::WarehouseBuilder
       # @return [Array]
       def self.samples_info_by_item_uuid(item_uuid)
         rows = self.where(:container_uuid => item_uuid).all
-        unless rows.empty?
-          rows.map do |r|
-            {
-              :sample_uuid => r.sample_uuid, 
-              :container_uuid => r.container_uuid, 
-              :container_model => r.container_model
-            }
-          end
-        else
-          raise NotFound, "no sample found for container #{item_uuid}"
+        rows.map do |r|
+          {
+            :sample_uuid => r.sample_uuid, 
+            :container_uuid => r.container_uuid, 
+            :container_model => r.container_model
+          }
         end
       end
-
-      # @param [String] uuid
-      # @return [Array<String>]
-      def self.sample_uuids_by_container_uuid(uuid)
-        row = self.where(:container_uuid => uuid).select(:sample_uuid).all
-        unless row.empty?
-          row.map { |r| r.sample_uuid }
-        else
-          raise NotFound, "no sample uuid found for container #{uuid}"
-        end
-      end
-
     end
   end
 end
-

--- a/lib/lims-warehousebuilder/models/item.rb
+++ b/lib/lims-warehousebuilder/models/item.rb
@@ -5,9 +5,31 @@ module Lims::WarehouseBuilder
     class Item < Sequel::Model(:historic_items)
 
       include ResourceTools::Mapping
+      # TODO: trigger in before_save to update items current table
+      # Handle only one row per item uuid. Need to be fixed if a resource
+      # appears in more than one order.
       include Common
 
-      translate(:batch__uuid => :batch_uuid)
+      def before_create
+        set_order_id!
+      end
+
+      def set_order_uuid(order_uuid)
+        @order_uuid = order_uuid
+      end
+
+      def self.item_by_uuid(item_uuid)
+        item = self.dataset.from(current_table_name).where(:uuid => item_uuid).first
+        raise NotFound, "The item corresponding to the resource #{item_uuid} cannot be found" unless item
+        item
+      end
+
+      private
+
+      def set_order_id!
+        order = Model.model_for_uuid(@order_uuid, "order")
+        self.order_id = order.internal_id
+      end
     end
   end
 end

--- a/lib/lims-warehousebuilder/models/order.rb
+++ b/lib/lims-warehousebuilder/models/order.rb
@@ -1,0 +1,15 @@
+module Lims::WarehouseBuilder
+  module Model
+    class Order < Sequel::Model(:historic_orders)
+      
+      include ResourceTools::Mapping
+      include Common
+
+      def self.order_by_id(order_id)
+        order = self.dataset.from(current_table_name).where(:internal_id => order_id).first
+        raise NotFound, "The order with internal_id #{order_id} cannot be found" unless order
+        order
+      end
+    end
+  end
+end

--- a/lib/lims-warehousebuilder/models/sample.rb
+++ b/lib/lims-warehousebuilder/models/sample.rb
@@ -24,6 +24,11 @@ module Lims::WarehouseBuilder
         :cellular_material__lysed => :cellular_material_lysed
       })
 
+      def self.sample_by_uuid(sample_uuid)
+        sample = self.dataset.from(current_table_name).where(:uuid => sample_uuid).first
+        raise NotFound, "The sample #{sample_uuid} cannot be found" unless sample
+        sample
+      end
     end
   end
 end

--- a/lib/lims-warehousebuilder/models/sample_management_activity.rb
+++ b/lib/lims-warehousebuilder/models/sample_management_activity.rb
@@ -1,4 +1,3 @@
-require 'lims-warehousebuilder/core_ext'
 require 'digest'
 
 module Lims::WarehouseBuilder

--- a/lib/lims-warehousebuilder/models/sample_management_activity.rb
+++ b/lib/lims-warehousebuilder/models/sample_management_activity.rb
@@ -6,7 +6,7 @@ module Lims::WarehouseBuilder
     class SampleManagementActivity < Sequel::Model(:sample_management_activity)
 
       def before_save
-        set_order_id!
+        set_order_id! if @order_uuid
         set_hashed_index!
         return false if has_duplicate?
         set_is_current!

--- a/lib/lims-warehousebuilder/models/sample_management_activity.rb
+++ b/lib/lims-warehousebuilder/models/sample_management_activity.rb
@@ -5,6 +5,7 @@ module Lims::WarehouseBuilder
     class SampleManagementActivity < Sequel::Model(:sample_management_activity)
 
       def before_save
+        super
         set_order_id! if @order_uuid
         set_hashed_index!
         return false if has_duplicate?

--- a/lib/lims-warehousebuilder/version.rb
+++ b/lib/lims-warehousebuilder/version.rb
@@ -1,5 +1,5 @@
 module Lims
   module WarehouseBuilder
-    VERSION = "0.5.1"
+    VERSION = "0.5.2"
   end
 end


### PR DESCRIPTION
- current_items and historic_items are correctly updated
- updating sample_management_activity table does not require to requeue message anymore (use items table efficiently)
